### PR TITLE
Fix failure in UTF-8 locales

### DIFF
--- a/unpack-initramfs
+++ b/unpack-initramfs
@@ -20,6 +20,9 @@ INITRAMFS_DIR=initramfs_root
 #GET CURRENT DIR
 CURRENT_DIR=`pwd`
 
+# Fixes binary grep not working with raw (high) bytes in UTF-8 locales.
+export LANG=C
+
 function pre_clean()
 {
     [ -z $DEBUG ] || echo "-D- Function: pre_clean()"


### PR DESCRIPTION
This fixes #1: detection failures of the gzip image in UTF-8 locales because of grep treating high bytes (MSB set) differently.